### PR TITLE
Added option for the [issuem_archives] shortcode to generate issue urls ...

### DIFF
--- a/issuem-class.php
+++ b/issuem-class.php
@@ -299,6 +299,7 @@ if ( ! class_exists( 'IssueM' ) ) {
 								'display_byline_as'		=> 'user_firstlast',
 								'issuem_author_name'	=> '',
 								'use_wp_taxonomies'		=> '',
+                                'use_issue_tax_links'   => '',
 								'article_format'		=> 	'<p class="issuem_article_category">%CATEGORY[1]%</p>' . "\n" .
 															'<p><a class="issuem_article_link" href="%URL%">%TITLE%</a></p>' . "\n" .
 															'<p class="issuem_article_content">%EXCERPT%</p>' . "\n" .
@@ -434,7 +435,12 @@ if ( ! class_exists( 'IssueM' ) ) {
 					$settings['use_wp_taxonomies'] = $_REQUEST['use_wp_taxonomies'];
 				else
 					unset( $settings['use_wp_taxonomies'] );
-				
+
+                if ( !empty( $_REQUEST['use_issue_tax_links'] ) )
+                    $settings['use_issue_tax_links'] = $_REQUEST['use_issue_tax_links'];
+                else
+                    unset( $settings['use_issue_tax_links'] );
+
 				$this->update_settings( $settings );
 					
 				// It's not pretty, but the easiest way to get the menu to refresh after save...
@@ -577,6 +583,11 @@ if ( ! class_exists( 'IssueM' ) ) {
                         	<tr>
                                 <th rowspan="1"> <?php _e( 'Use Default WordPress Category and Tag Taxonomies', 'issuem' ); ?></th>
                                 <td><input type="checkbox" id="use_wp_taxonomies" name="use_wp_taxonomies" <?php checked( $settings['use_wp_taxonomies'] || 'on' == $settings['use_wp_taxonomies'] ); ?>" /></td>
+                            </tr>
+
+                            <tr>
+                                <th rowspan="1"> <?php _e( 'Use Taxonomical links instead of shortcode based links for Issues', 'issuem' ); ?></th>
+                                <td><input type="checkbox" id="use_issue_tax_links" name="use_issue_tax_links" <?php checked( $settings['use_issue_tax_links'] || 'on' == $settings['use_issue_tax_links'] ); ?>" /></td>
                             </tr>
                             
                         </table>

--- a/issuem-shortcodes.php
+++ b/issuem-shortcodes.php
@@ -328,7 +328,10 @@ if ( !function_exists( 'do_issuem_archives' ) ) {
 			else
 				$article_page = get_page_link( $issuem_settings['page_for_articles'] );
 		
-			$issue_url = add_query_arg( 'issue', $issue_array[0]->slug, $article_page );
+			$issue_url = get_term_link( $issue_array[0], 'issuem_issue' );
+            if ( $issuem_settings['use_issue_tax_links'] == '' or is_wp_error( $issue_url ) ) {
+                $issue_url = add_query_arg( 'issue', $issue_array[0]->slug, $article_page );
+            }
 				
 			if ( !empty( $issue_array[1]['pdf_version'] ) || !empty( $issue_meta['external_pdf_link'] ) ) {
 				


### PR DESCRIPTION
...using get_term_link instead of based on the shortcode page with a backup to the previous links in the event of an error
