### PR TITLE
Applies 'the_content' filter to article content

### DIFF
--- a/issuem-functions.php
+++ b/issuem-functions.php
@@ -370,7 +370,7 @@ if ( !function_exists( 'issuem_replacements_args' ) ) {
 		
 		if ( preg_match( '/%CONTENT%/i', $string, $matches ) ) {
 		
-			$content = get_the_content();
+			$content = apply_filters( 'the_content', get_the_content() );
 			$string = preg_replace( '/%CONTENT%/i', $content, $string );	
 					
 		}


### PR DESCRIPTION
Solves problem with missing paragraph tags when displaying article %CONTENT%. I was thinking about creating a separate custom replacement tag like %CONTENT_FORMATTED%, but this is simpler.
