### PR TITLE
fix "order by issue" in admin

### DIFF
--- a/issuem-taxonomy.php
+++ b/issuem-taxonomy.php
@@ -125,7 +125,7 @@ if ( !function_exists( 'issuem_issue_sortable_column_orderby' ) )  {
 		global $hook_suffix;
 
 		if ( 'edit-tags.php' == $hook_suffix && in_array( 'issuem_issue', $taxonomies ) 
-				&& ( empty( $_GET['orderby'] ) && !empty( $args['orderby'] ) && 'issue_order' == $args['orderby'] ) ) {
+				&& ( !empty( $_GET['orderby'] ) && !empty( $args['orderby'] ) && 'issue_order' == $args['orderby'] ) ) {
 				
 			$sort = array();
 			$count = 0;


### PR DESCRIPTION
When looking at the list of issues in the WordPress admin screen, the "Issue Order" column is sortable so that the user can review the list of issues in order. That functionality wasn't working, though -- the system wasn't sorting properly at all -- and this PR fixes the bug.