### PR TITLE
Fixes error notice after saving issuem settings for sites in multisite

### DIFF
--- a/issuem-class.php
+++ b/issuem-class.php
@@ -515,7 +515,7 @@ if ( ! class_exists( 'IssueM' ) ) {
 				?>
 					<script type="text/javascript">
 					<!--
-					window.location = "<?php echo $_SERVER['PHP_SELF'] .'?post_type=article&page=issuem&settings_saved=true'; ?>"
+					window.location = "<?php echo admin_url('edit.php?post_type=article&page=issuem&settings_saved=true'); ?>"
 					//-->
 					</script>
 				<?php


### PR DESCRIPTION
This gets rid of the error message ‘You do not have sufficient permissions to access this page’ when saving IssueM Settings on multisite.

This replaces $_SERVER['PHP_SELF'] with admin_url() so that users will be redirected to the site where IssueM is active instead of the main network site.