### PR TITLE
Two action hooks to allow multiple article formats

### DIFF
--- a/issuem-class.php
+++ b/issuem-class.php
@@ -749,7 +749,12 @@ if ( ! class_exists( 'IssueM' ) ) {
 
 	                        <p>This controls the article output of the [issuem_articles] shortcode on the Current Issue page.</p>
 	                        
+	                        <?php do_action( 'issuem_before_default_article_format' ); ?>
+
 	                        <textarea id="article_format" class="code" cols="75" rows="8" name="article_format"><?php echo htmlspecialchars( stripcslashes( $settings['article_format'] ) ); ?></textarea>
+	                        
+	                        <?php do_action( 'issuem_after_default_article_format' ); ?>
+
 	                        <p>Available template tags:<br> %CATEGORY%, %TAG%, %TEASER%, %EXCERPT%, %CONTENT%, %FEATURE_IMAGE%, %ISSUEM_FEATURE_THUMB%, %BYLINE%, and %DATE%</p>
 	                                                  
 	                        <p class="submit">


### PR DESCRIPTION
Action hooks that let people (who also understand the rest of the class) create multiple possible article formats, all present on the IssueM settings page.